### PR TITLE
Include Editor and Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 **Current Spec version:** `v.0.1.0` (see [CHANGELOG.md](CHANGELOG.md))
 
+**Editor** Solid Specification Repository Manager
+
+**Contributors**
+
 WebID-OIDC is an authentication delegation protocol (as well as a toolkit of
 useful auth-related verification techniques) suitable for WebID-based
 decentralized systems such as [Solid](https://github.com/solid/solid), as well


### PR DESCRIPTION
At the W3C Solid Community Group call on the 11th April it was decided to include the spec editor and contributors to each of the Solid specification repositories. The editor is clearly the Solid Specifications Repository Manager. 

Please join to the conversation on what you think should be the criteria to be included as a contributor on https://github.com/solid/solid-spec/pull/155

This is a good place to put your name if you would like to be included as a contributor to this repository.