### PR TITLE
Removed references to TLS that imply it is the primary form of authenication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ as most LDP-based systems. It is based on decentralized OAuth2/OpenID Connect.
 
 The end result of any WebID-based authentication workflow is a verified WebID
 URI (specifically, the recipient verifies that the agent controls that URI).
-For example,
-[WebID-TLS](https://github.com/solid/solid-spec/blob/master/authn-webid-tls.md)
-derives the WebID URI from a TLS certificate, and verifies the certificate
-against the public key in an agent's WebID Profile. Similarly, the end result of
+For example, the end result of
 [OpenID Connect (OIDC)](https://openid.net/specs/openid-connect-core-1_0.html)
 workflows is a verified ID Token. The WebID-OIDC protocol specifies a mechanism
 for getting a WebID URI from an OIDC ID Token, and gains the benefits of both

--- a/motivation.md
+++ b/motivation.md
@@ -1,9 +1,7 @@
 ## Motivation for WebID-OIDC
 
 The Solid team, while [researching additional authentication
-mechanisms](https://github.com/solid/solid/issues/22) to run alongside the
-existing one
-([WebID-TLS](https://github.com/solid/solid-spec/blob/master/authn-webid-tls.md)),
+mechanisms](https://github.com/solid/solid/issues/22),
 performed a review of existing authentication protocols that has been used by
 (or proposed for) decentralized application ecosystems. Several criteria were
 kept in mind.


### PR DESCRIPTION
TLS as a primary form of authentication should be deprecated in favor of a oidc. TLS may still be used as a form of credentials under oidc. All concerns about needing completely decentralized identity systems will be solved with an eventual implementation of DiD.